### PR TITLE
Fix undesired disabling of buttons

### DIFF
--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/EditTextNotesFragment.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/EditTextNotesFragment.kt
@@ -37,7 +37,9 @@ class EditTextNotesFragment: BaseEditNoteFragment() {
     }
 
     private val windowFocusedListener = OnWindowFocusChangeListener {
-        observeClipboardContent()
+        if (it) {
+            observeClipboardContent()
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/EditTextNotesFragment.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/EditTextNotesFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
+import android.view.ViewTreeObserver.OnWindowFocusChangeListener
 import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
@@ -33,6 +34,10 @@ class EditTextNotesFragment: BaseEditNoteFragment() {
             else Toast.makeText(requireContext(),
                 getString(R.string.nothing_to_paste), Toast.LENGTH_SHORT).show()
         }
+    }
+
+    private val windowFocusedListener = OnWindowFocusChangeListener {
+        observeClipboardContent()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -100,6 +105,8 @@ class EditTextNotesFragment: BaseEditNoteFragment() {
         binding.toolbar.ivRightActionIcon.setOnClickListener {
             showDeleteNoteDialog(note)
         }
+
+        view.viewTreeObserver.addOnWindowFocusChangeListener(windowFocusedListener)
     }
 
     override fun isContentChanged(): Boolean {
@@ -111,9 +118,9 @@ class EditTextNotesFragment: BaseEditNoteFragment() {
         return binding.editNote.text.toString().trim().isEmpty()
     }
 
-    override fun onResume() {
-        super.onResume()
-        observeClipboardContent()
+    override fun onDestroyView() {
+        super.onDestroyView()
+        view?.viewTreeObserver?.removeOnWindowFocusChangeListener(windowFocusedListener)
     }
 
     override fun createNewNote(): Note {


### PR DESCRIPTION
We were having ```null``` ```primaryClip``` from clipboard causing the ```clipboardTextEmpty``` value to be wrong
```
private fun observeClipboardContent() {
        context?.getTextFromClipBoard(view) {
            val clipboardTextEmpty = it.isNullOrEmpty()
            if (clipboardTextEmpty) {
                binding.tvPaste.alpha = 0.4f
                binding.tvPaste.isClickable = false
            } else {
                binding.tvPaste.alpha = 1f
                binding.tvPaste.isClickable = true
            }
            enableSaveText(!clipboardTextEmpty && isContentChanged())
        }
    }
```

[Android 10 Clipboard Changes](https://developer.android.com/about/versions/10/privacy/changes#clipboard-data)