### PR TITLE
Update filepicker library version to 0.2.0

### DIFF
--- a/app/src/main/java/dev/arkbuilders/arkmemo/App.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/App.kt
@@ -2,7 +2,7 @@ package dev.arkbuilders.arkmemo
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
-import dev.arkbuilders.arkfilepicker.folders.FoldersRepo
+import dev.arkbuilders.arklib.data.folders.FoldersRepo
 import dev.arkbuilders.arklib.initArkLib
 import dev.arkbuilders.arkmemo.preferences.MemoPreferences
 import javax.inject.Inject

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/activities/MainActivity.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/activities/MainActivity.kt
@@ -12,7 +12,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import by.kirich1409.viewbindingdelegate.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
-import dev.arkbuilders.arkfilepicker.presentation.onArkPathPicked
 import dev.arkbuilders.arkmemo.R
 import dev.arkbuilders.arkmemo.contracts.PermissionContract
 import dev.arkbuilders.arkmemo.databinding.ActivityMainBinding
@@ -21,6 +20,7 @@ import dev.arkbuilders.arkmemo.ui.dialogs.FilePickerDialog
 import dev.arkbuilders.arkmemo.ui.fragments.BaseFragment
 import dev.arkbuilders.arkmemo.ui.fragments.EditTextNotesFragment
 import dev.arkbuilders.arkmemo.ui.fragments.NotesFragment
+import dev.arkbuilders.components.filepicker.onArkPathPicked
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/dialogs/FilePickerDialog.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/dialogs/FilePickerDialog.kt
@@ -10,12 +10,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
 import dagger.hilt.android.AndroidEntryPoint
-import dev.arkbuilders.arkfilepicker.ArkFilePickerConfig
-import dev.arkbuilders.arkfilepicker.presentation.filepicker.ArkFilePickerFragment
-import dev.arkbuilders.arkfilepicker.presentation.filepicker.ArkFilePickerMode
 import dev.arkbuilders.arkmemo.BuildConfig
 import dev.arkbuilders.arkmemo.R
 import dev.arkbuilders.arkmemo.preferences.MemoPreferences
+import dev.arkbuilders.components.filepicker.ArkFilePickerConfig
+import dev.arkbuilders.components.filepicker.ArkFilePickerFragment
+import dev.arkbuilders.components.filepicker.ArkFilePickerMode
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ constraintlayout = "2.1.4"
 navigationFragmentKtx = "2.5.2"
 preferenceKtx = "1.2.0"
 lifecycleViewmodelKtx = "2.5.1"
-arkFilepicker = "0.1.1"
+arkFilepicker = "0.2.0"
 arkLib = "0.3.5"
 googleHiltAndroid = "2.48"
 googleHiltCompiler = "2.48"
@@ -59,7 +59,7 @@ androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref
 androidx-test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidXTestEspresso" }
 skydoves-balloon = { group = "com.github.skydoves", name = "balloon", version.ref = "skydovesBalloon" }
 flexbox = { group = "com.google.android.flexbox", name = "flexbox", version.ref = "flexbox" }
-arkbuilders-arkfilepicker = { group = "dev.arkbuilders", name = "arkfilepicker", version.ref = "arkFilepicker" }
+arkbuilders-arkfilepicker = { group = "dev.arkbuilders.components", name = "filepicker", version.ref = "arkFilepicker" }
 arkbuilders-arklib = { group = "dev.arkbuilders", name = "arklib", version.ref = "arkLib" }
 airbnb-lottie = { group = "com.airbnb.android", name = "lottie", version.ref = "airbnbLottie" }
 qr-generator = { group = "com.github.androidmads", name = "QRGenerator", version.ref = "qrgenerator" }


### PR DESCRIPTION
Update filepicker library version to `0.2.0`.
This PR should only be merged once https://github.com/ARK-Builders/ARK-Memo/pull/57 is merged.

Related issue: https://github.com/ARK-Builders/ARK-Memo/issues/60