### PR TITLE
Hide EditText's cursor when keyboard is hidden and vice versa

### DIFF
--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/EditTextNotesFragment.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/EditTextNotesFragment.kt
@@ -6,6 +6,8 @@ import android.text.TextWatcher
 import android.view.View
 import android.view.ViewTreeObserver.OnWindowFocusChangeListener
 import android.widget.Toast
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import dagger.hilt.android.AndroidEntryPoint
@@ -82,6 +84,15 @@ class EditTextNotesFragment: BaseEditNoteFragment() {
         editNote.addTextChangedListener {
             enableSaveText(isContentChanged() && !isContentEmpty())
         }
+
+        activity?.window?.decorView?.rootView?.let { rootView ->
+            ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
+                val isKeyboardVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
+                editNote.isCursorVisible = isKeyboardVisible
+                insets
+            }
+        }
+
         editNote.isVisible = true
         editNote.requestFocus()
         editNote.setText(this.note.text)

--- a/app/src/main/java/dev/arkbuilders/arkmemo/utils/StringExt.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/utils/StringExt.kt
@@ -1,0 +1,11 @@
+package dev.arkbuilders.arkmemo.utils
+
+fun String.insertStringAtPosition(stringToInsert: String, position: Int): String {
+    if (position < 0 || position > this.length) {
+        throw IndexOutOfBoundsException("Position is out of bounds of the string")
+    }
+
+    val stringBuilder = StringBuilder(this)
+    stringBuilder.insert(position, stringToInsert)
+    return stringBuilder.toString()
+}

--- a/app/src/test/java/dev/arkbuilders/arkmemo/utils/StringExtTest.kt
+++ b/app/src/test/java/dev/arkbuilders/arkmemo/utils/StringExtTest.kt
@@ -1,0 +1,71 @@
+package dev.arkbuilders.arkmemo.utils
+
+import org.junit.Assert.*
+
+import org.junit.Test
+
+class StringExtTest {
+
+    @Test
+    fun `insert string in the middle of another string`() {
+        val result = "Hello World".insertStringAtPosition("Beautiful ", 6)
+        assertEquals("Hello Beautiful World", result)
+    }
+
+    @Test
+    fun `insert string at the beginning`() {
+        val result = "World".insertStringAtPosition("Hello ", 0)
+        assertEquals("Hello World", result)
+    }
+
+    @Test
+    fun `insert string at the end`() {
+        val result = "Hello".insertStringAtPosition(" World", 5)
+        assertEquals("Hello World", result)
+    }
+
+    @Test
+    fun `insert string into an empty string`() {
+        val result = "".insertStringAtPosition("Hello", 0)
+        assertEquals("Hello", result)
+    }
+
+    @Test
+    fun `insert empty string at any position`() {
+        val result = "Hello World".insertStringAtPosition("", 5)
+        assertEquals("Hello World", result)
+    }
+
+    @Test
+    fun `insert string at out-of-bound negative position throws exception`() {
+        assertThrows(IndexOutOfBoundsException::class.java) {
+            "Hello World".insertStringAtPosition("Test", -1)
+        }
+    }
+
+    @Test
+    fun `insert string at out-of-bound position greater than length throws exception`() {
+        assertThrows(IndexOutOfBoundsException::class.java) {
+            "Hello".insertStringAtPosition("World", 10)
+        }
+    }
+
+    @Test
+    fun `insert string into a string with special characters`() {
+        val result = "Hello @#$%!".insertStringAtPosition("Beautiful ", 6)
+        assertEquals("Hello Beautiful @#$%!", result)
+    }
+
+    @Test
+    fun `insert string into a single-character string`() {
+        val result = "A".insertStringAtPosition("B", 1)
+        assertEquals("AB", result)
+    }
+
+    @Test
+    fun `insert string with newline characters`() {
+        val result = "Hello\nWorld".insertStringAtPosition(" Beautiful", 5)
+        assertEquals("Hello Beautiful\nWorld", result)
+    }
+
+}


### PR DESCRIPTION
- Hide EditText's cursor when keyboard is hidden and vice versa: https://app.asana.com/0/1207819682524134/1208211226661165
- [enhance] Pasting a text should append it to the current cursor position in Text note: https://app.asana.com/0/1207819682524134/1208091975005939