### PR TITLE
Back gesture is recognized as drawing intent

### DIFF
--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/views/NotesCanvas.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/views/NotesCanvas.kt
@@ -1,6 +1,7 @@
 package dev.arkbuilders.arkmemo.ui.views
 
 import android.content.Context
+import android.content.res.Resources
 import android.graphics.Canvas
 import android.graphics.Path
 import android.util.AttributeSet
@@ -18,6 +19,8 @@ class NotesCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) 
     private lateinit var viewModel: GraphicNotesViewModel
     private var path = Path()
 
+    private val screenWidth by lazy { Resources.getSystem().displayMetrics.widthPixels }
+
     override fun onDraw(canvas: Canvas) {
         val paths = viewModel.paths()
         if (paths.isNotEmpty()) {
@@ -30,6 +33,14 @@ class NotesCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         val x = event.x
         val y = event.y
+
+        val edgeThreshold = 50
+
+        // When touch point starts from either of the left or right side of the screen,
+        // that's probably a back gesture. Do not draw in this case
+        if (x < edgeThreshold || x > screenWidth - edgeThreshold) {
+            return false
+        }
 
         var finishDrawing = false
         when (event.action) {


### PR DESCRIPTION
### Problem

When back gesture navigation is made from either left or right side of screen, it's mistakenly recognized as a drawing intent
in graphics note edit mode. This affects badly on UX.

https://app.asana.com/0/1207819682524134/1208536199909620

### Solution

Do not draw if the gesture touch point is made within the edge (either left or right) side of screen.

### Before

https://github.com/user-attachments/assets/f67e18bc-004f-49ad-8a47-7c59fcb902dc


### After


https://github.com/user-attachments/assets/e3bbea7b-994c-4596-be75-24468c445c23



