### PR TITLE
Enable R8 for code & resource shrinking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,8 @@ android {
             ]
         }
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.testRelease
             manifestPlaceholders = [

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,9 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-keep class dev.arkbuilders.arklib.** { *; }
+-dontwarn javax.xml.stream.XMLResolver
+-dontwarn org.slf4j.impl.StaticLoggerBinder
+-dontobfuscate
+
+-keepattributes Signature

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/adapters/NotesListAdapter.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/adapters/NotesListAdapter.kt
@@ -72,6 +72,8 @@ class NotesListAdapter(
 
         if (note is TextNote) {
             holder.contentPreview.text = note.text
+        } else {
+            holder.contentPreview.text = ""
         }
         holder.layoutAudioView.root.gone()
         holder.ivGraphicThumb.gone()


### PR DESCRIPTION
* Enable R8 with custom proguard fules for resource shrinking/unused code removal without code obfuscation
* Bug fix: Do not display text content preview for Voice/Graphics note

Ticket: https://app.asana.com/0/1207829522063916/1208582993032059