### PR TITLE
Migrate hardcoded dependencies to version catalog

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
     id 'kotlin-kapt'
-    id 'dagger.hilt.android.plugin'
+    alias(libs.plugins.hilt.android)
     id 'kotlin-parcelize'
-    id 'com.google.gms.google-services'
-    id 'com.google.firebase.crashlytics'
-    id 'org.jlleitschuh.gradle.ktlint'
+    alias(libs.plugins.google.services)
+    alias(libs.plugins.firebase.crashlytics)
+    alias(libs.plugins.gradle.ktlint)
 }
 
 android {
@@ -81,36 +81,35 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.6.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.2'
-    implementation 'androidx.preference:preference-ktx:1.2.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
+    implementation(libraries.androidx.core.ktx)
+    implementation(libraries.androidx.appcompat)
+    implementation(libraries.android.material)
+    implementation(libraries.androidx.constraintlayout)
+    implementation(libraries.androidx.navigation.fragment.ktx)
+    implementation(libraries.androidx.preference.ktx)
+    implementation(libraries.androidx.lifecycle.viewmodel.ktx)
 
-    implementation 'dev.arkbuilders:arkfilepicker:0.1.1'
-    implementation 'dev.arkbuilders:arklib:0.3.3'
+    implementation(libraries.arkbuilders.arkfilepicker)
+    implementation(libraries.arkbuilders.arklib)
 
-    implementation 'androidx.preference:preference:1.2.0'
-    implementation "com.google.dagger:hilt-android:2.48"
-    kapt "com.google.dagger:hilt-compiler:2.48"
-    kapt 'androidx.hilt:hilt-compiler:1.0.0'
+    implementation(libraries.google.dagger.hilt.android)
+    kapt(libraries.google.dagger.hilt.compiler)
+    kapt(libraries.androidx.hilt.compiler)
 
-    implementation 'com.github.kirich1409:viewbindingpropertydelegate-noreflection:1.5.9'
+    implementation(libraries.viewbinding.property.delegate.noreflection)
 
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    testImplementation(libraries.junit)
+    androidTestImplementation(libraries.androidx.test.junit)
+    androidTestImplementation(libraries.androidx.test.espresso)
 
-    implementation 'com.airbnb.android:lottie:6.4.0'
-    implementation 'com.github.androidmads:QRGenerator:1.0.1'
-    implementation("io.coil-kt:coil:2.6.0")
-    implementation("com.github.skydoves:balloon:1.6.4")
+    implementation(libraries.airbnb.lottie)
+    implementation(libraries.qr.generator)
+    implementation(libraries.coil)
+    implementation(libraries.skydoves.balloon)
 
-    implementation platform('com.google.firebase:firebase-bom:33.3.0')
-    implementation "com.google.firebase:firebase-crashlytics"
-    implementation "com.google.firebase:firebase-analytics"
+    implementation(platform(libraries.google.firebase.bom))
+    implementation(libraries.google.firebase.crashlytics)
+    implementation(libraries.google.firebase.analytics)
 }
 
 tasks.preBuild.dependsOn ktlintCheck

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,11 @@
-buildscript {
-    ext {
-        compose_version = '1.3.0-beta01'
-    }
-    ext.kotlin_version="1.9.24"
-}
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.3.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
-    id 'com.google.dagger.hilt.android' version '2.48' apply false
-    id 'com.google.gms.google-services' version '4.4.2' apply false
-    id 'com.google.firebase.crashlytics' version '3.0.2' apply false
-    id 'org.jlleitschuh.gradle.ktlint' version '12.1.1'
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.hilt.android) apply false
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
+    alias(libs.plugins.gradle.ktlint) apply false
 }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,73 @@
+[versions]
+coil = "2.6.0"
+androidxFragmentKtx = "1.6.1"
+orbitMvi = "6.1.0"
+viewbindingPropertyDelegate = "1.5.9"
+androidXCore = "1.9.0"
+androidXAppcompat = "1.6.1"
+androidMaterial = "1.11.0"
+androidGradlePlugin = "8.3.0"
+kotlinAndroidPlugin = "1.9.24"
+hiltAndroidPlugin = "2.48"
+googleServicesPlugin = "4.4.2"
+firebaseCrashlyticsPlugin = "3.0.2"
+gradleKtLintPlugin = "12.1.1"
+junit = "4.13.2"
+androidXTestJunit = "1.1.5"
+androidXTestEspresso = "3.5.1"
+skydovesBalloon = "1.6.4"
+flexbox = "3.0.0"
+constraintlayout = "2.1.4"
+navigationFragmentKtx = "2.5.2"
+preferenceKtx = "1.2.0"
+lifecycleViewmodelKtx = "2.5.1"
+arkFilepicker = "0.1.1"
+arkLib = "0.3.5"
+googleHiltAndroid = "2.48"
+googleHiltCompiler = "2.48"
+googleFirebaseBom = "33.3.0"
+androidxHiltCompiler = "1.0.0"
+airbnbLottie = "6.4.0"
+qrgenerator = "1.0.1"
+
+[libraries]
+coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
+coil-gif = { group = "io.coil-kt", name = "coil-gif", version.ref = "coil" }
+coil-svg = { group = "io.coil-kt", name = "coil-svg", version.ref = "coil" }
+coil-video = { group = "io.coil-kt", name = "coil-video", version.ref = "coil" }
+androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragmentKtx" }
+orbit-mvi-viewmodel = { group = "org.orbit-mvi", name = "orbit-viewmodel", version.ref = "orbitMvi" }
+orbit-mvi-compose = { group = "org.orbit-mvi", name = "orbit-compose", version.ref = "orbitMvi" }
+viewbinding-property-delegate-noreflection = { group = "com.github.kirich1409", name = "viewbindingpropertydelegate-noreflection", version.ref = "viewbindingPropertyDelegate" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidXCore" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidXAppcompat" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
+androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preferenceKtx" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
+androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "androidxHiltCompiler" }
+
+google-dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "googleHiltAndroid" }
+google-dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "googleHiltCompiler" }
+google-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "googleFirebaseBom" }
+google-firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics", version = "none" }
+google-firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics", version = "none" }
+
+android-material = { group = "com.google.android.material", name = "material", version.ref = "androidMaterial" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidXTestJunit" }
+androidx-test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidXTestEspresso" }
+skydoves-balloon = { group = "com.github.skydoves", name = "balloon", version.ref = "skydovesBalloon" }
+flexbox = { group = "com.google.android.flexbox", name = "flexbox", version.ref = "flexbox" }
+arkbuilders-arkfilepicker = { group = "dev.arkbuilders", name = "arkfilepicker", version.ref = "arkFilepicker" }
+arkbuilders-arklib = { group = "dev.arkbuilders", name = "arklib", version.ref = "arkLib" }
+airbnb-lottie = { group = "com.airbnb.android", name = "lottie", version.ref = "airbnbLottie" }
+qr-generator = { group = "com.github.androidmads", name = "QRGenerator", version.ref = "qrgenerator" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin"}
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinAndroidPlugin"}
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hiltAndroidPlugin"}
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServicesPlugin"}
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin"}
+gradle-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "gradleKtLintPlugin"}

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,12 @@ dependencyResolutionManagement {
             }
         }
     }
+
+    versionCatalogs {
+        create("libraries") {
+            from(files("./gradle/libs.versions.toml"))
+        }
+    }
 }
 
 rootProject.name = "ARK Memo"


### PR DESCRIPTION
Migrate hardcoded dependencies to version catalog.

`[Gradle version catalogs](https://docs.gradle.org/current/userguide/platforms.html) enable you to add and maintain dependencies and plugins in a scalable way. Using Gradle version catalogs makes managing dependencies and plugins easier when you have [multiple modules](https://developer.android.com/topic/modularization). Instead of hardcoding dependency names and versions in individual build files and updating each entry whenever you need to upgrade a dependency, you can create a central version catalog of dependencies that various modules can reference in a type-safe way with Android Studio assistance.`

https://app.asana.com/0/1207819682524134/1208308884950165
https://developer.android.com/build/migrate-to-catalogs