### PR TITLE
Fix storage permission related crash in Android 10

### DIFF
--- a/app/src/main/java/dev/arkbuilders/arkmemo/contracts/PermissionContract.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/contracts/PermissionContract.kt
@@ -14,7 +14,9 @@ class PermissionContract : ActivityResultContract<String, Boolean>() {
     override fun createIntent(
         context: Context,
         input: String,
-    ) = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, Uri.parse(input))
+    ) = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, Uri.parse(input)).apply {
+        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+    }
 
     @RequiresApi(Build.VERSION_CODES.R)
     override fun parseResult(

--- a/app/src/main/java/dev/arkbuilders/arkmemo/models/NoteType.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/models/NoteType.kt
@@ -1,0 +1,7 @@
+package dev.arkbuilders.arkmemo.models
+
+enum class NoteType {
+    TEXT,
+    VOICE,
+    GRAPHIC,
+}

--- a/app/src/main/java/dev/arkbuilders/arkmemo/repo/NotesRepo.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/repo/NotesRepo.kt
@@ -1,5 +1,6 @@
 package dev.arkbuilders.arkmemo.repo
 
+import dev.arkbuilders.arklib.ResourceId
 import dev.arkbuilders.arkmemo.models.SaveNoteResult
 
 interface NotesRepo<Note> {
@@ -15,4 +16,6 @@ interface NotesRepo<Note> {
     suspend fun delete(note: Note)
 
     suspend fun delete(notes: List<Note>)
+
+    suspend fun findNote(id: ResourceId): Note?
 }

--- a/app/src/main/java/dev/arkbuilders/arkmemo/repo/graphics/GraphicNotesRepo.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/repo/graphics/GraphicNotesRepo.kt
@@ -8,6 +8,7 @@ import android.graphics.Canvas
 import android.os.Environment
 import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.arkbuilders.arklib.ResourceId
 import dev.arkbuilders.arklib.computeId
 import dev.arkbuilders.arklib.data.index.Resource
 import dev.arkbuilders.arkmemo.R
@@ -118,32 +119,19 @@ class GraphicNotesRepo
             withContext(iODispatcher) {
                 Log.d(GRAPHICS_REPO, "readStorage")
                 root.listFiles(SVG_EXT) { path ->
-                    val svg = SVG.parse(path)
-                    if (svg == null) {
-                        Log.w(GRAPHICS_REPO, "Skipping invalid SVG: " + path)
-                    }
-                    val size = path.fileSize()
-                    val id = computeId(size, path)
-                    val resource =
-                        Resource(
-                            id = id,
-                            name = path.fileName.name,
-                            extension = path.extension,
-                            modified = path.getLastModifiedTime(),
-                        )
-
-                    val userNoteProperties = helper.readProperties(id, "")
-                    val bitmap = exportBitmapFromSvg(fileName = id.toString(), svg = svg)
-
-                    GraphicNote(
-                        title = userNoteProperties.title,
-                        description = userNoteProperties.description,
-                        svg = svg,
-                        resource = resource,
-                        thumb = bitmap,
-                    )
+                    path.toGraphicNote(helper = helper)
                 }.filter { graphicNote -> graphicNote.svg != null }
             }
+
+        override suspend fun findNote(id: ResourceId): GraphicNote? {
+            return withContext(iODispatcher) {
+                root.listFiles(SVG_EXT) { path ->
+                    path.toGraphicNote(helper = helper)
+                }.firstOrNull { graphicNote ->
+                    graphicNote.svg != null && id == graphicNote.resource?.id
+                }
+            }
+        }
 
         private fun exportBitmapFromSvg(
             fileName: String,
@@ -207,6 +195,33 @@ class GraphicNotesRepo
                 e.printStackTrace()
                 return null
             }
+        }
+
+        private fun Path.toGraphicNote(helper: NotesRepoHelper): GraphicNote {
+            val svg = SVG.parse(this)
+            if (svg == null) {
+                Log.w(GRAPHICS_REPO, "Skipping invalid SVG: " + this)
+            }
+            val size = this.fileSize()
+            val id = computeId(size, this)
+            val resource =
+                Resource(
+                    id = id,
+                    name = this.fileName.name,
+                    extension = this.extension,
+                    modified = this.getLastModifiedTime(),
+                )
+
+            val userNoteProperties = helper.readProperties(id, "")
+            val bitmap = exportBitmapFromSvg(fileName = id.toString(), svg = svg)
+
+            return GraphicNote(
+                title = userNoteProperties.title,
+                description = userNoteProperties.description,
+                svg = svg,
+                resource = resource,
+                thumb = bitmap,
+            )
         }
     }
 

--- a/app/src/main/java/dev/arkbuilders/arkmemo/repo/text/TextNotesRepo.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/repo/text/TextNotesRepo.kt
@@ -1,6 +1,7 @@
 package dev.arkbuilders.arkmemo.repo.text
 
 import android.util.Log
+import dev.arkbuilders.arklib.ResourceId
 import dev.arkbuilders.arklib.computeId
 import dev.arkbuilders.arklib.data.index.Resource
 import dev.arkbuilders.arkmemo.di.IO_DISPATCHER
@@ -55,6 +56,10 @@ class TextNotesRepo
             withContext(iODispatcher) {
                 readStorage()
             }
+
+        override suspend fun findNote(id: ResourceId): TextNote? {
+            return null
+        }
 
         private suspend fun write(
             note: TextNote,

--- a/app/src/main/java/dev/arkbuilders/arkmemo/repo/voices/VoiceNotesRepo.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/repo/voices/VoiceNotesRepo.kt
@@ -1,6 +1,7 @@
 package dev.arkbuilders.arkmemo.repo.voices
 
 import android.util.Log
+import dev.arkbuilders.arklib.ResourceId
 import dev.arkbuilders.arklib.computeId
 import dev.arkbuilders.arklib.data.index.Resource
 import dev.arkbuilders.arkmemo.di.IO_DISPATCHER
@@ -38,6 +39,16 @@ class VoiceNotesRepo
             withContext(iODispatcher) {
                 readStorage()
             }
+
+        override suspend fun findNote(id: ResourceId): VoiceNote? {
+            return withContext(iODispatcher) {
+                root.listFiles(VOICE_EXT) { path ->
+                    path.toVoiceNote(helper = helper)
+                }.firstOrNull { voiceNote ->
+                    voiceNote.duration.isNotEmpty() && id == voiceNote.resource?.id
+                }
+            }
+        }
 
         override suspend fun delete(notes: List<VoiceNote>) {
             helper.deleteNotes(notes)
@@ -103,25 +114,29 @@ class VoiceNotesRepo
             withContext(iODispatcher) {
                 Log.d(VOICES_REPO, "readStorage")
                 root.listFiles(VOICE_EXT) { path ->
-                    val id = computeId(path.fileSize(), path)
-                    val resource =
-                        Resource(
-                            id = id,
-                            name = path.name,
-                            extension = path.extension,
-                            modified = path.getLastModifiedTime(),
-                        )
-
-                    val userNoteProperties = helper.readProperties(id, "")
-                    VoiceNote(
-                        title = userNoteProperties.title,
-                        description = userNoteProperties.description,
-                        path = path,
-                        duration = extractDuration(path.pathString),
-                        resource = resource,
-                    )
+                    path.toVoiceNote(helper)
                 }.filter { voiceNote -> voiceNote.duration.isNotEmpty() }
             }
+
+        private fun Path.toVoiceNote(helper: NotesRepoHelper): VoiceNote {
+            val id = computeId(this.fileSize(), this)
+            val resource =
+                Resource(
+                    id = id,
+                    name = this.name,
+                    extension = this.extension,
+                    modified = this.getLastModifiedTime(),
+                )
+
+            val userNoteProperties = helper.readProperties(id, "")
+            return VoiceNote(
+                title = userNoteProperties.title,
+                description = userNoteProperties.description,
+                path = this,
+                duration = extractDuration(this.pathString),
+                resource = resource,
+            )
+        }
     }
 
 private const val VOICES_REPO = "VoiceNotesRepo"

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/activities/MainActivity.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/activities/MainActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.WindowManager
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
@@ -14,7 +13,6 @@ import androidx.fragment.app.Fragment
 import by.kirich1409.viewbindingdelegate.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import dev.arkbuilders.arkmemo.R
-import dev.arkbuilders.arkmemo.contracts.PermissionContract
 import dev.arkbuilders.arkmemo.databinding.ActivityMainBinding
 import dev.arkbuilders.arkmemo.models.RootNotFound
 import dev.arkbuilders.arkmemo.preferences.MemoPreferences
@@ -23,6 +21,7 @@ import dev.arkbuilders.arkmemo.ui.dialogs.FilePickerDialog
 import dev.arkbuilders.arkmemo.ui.fragments.BaseFragment
 import dev.arkbuilders.arkmemo.ui.fragments.EditTextNotesFragment
 import dev.arkbuilders.arkmemo.ui.fragments.NotesFragment
+import dev.arkbuilders.arkmemo.utils.PermissionManager
 import dev.arkbuilders.components.filepicker.onArkPathPicked
 import javax.inject.Inject
 import kotlin.io.path.exists
@@ -38,27 +37,10 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
     private val fragContainer = R.id.container
 
     var fragment: Fragment = NotesFragment()
+    val permissionManager = PermissionManager(activity = this)
 
     init {
-        FilePickerDialog.readPermLauncher =
-            registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
-                Log.d(ACTIVITY_TAG, "readPermLauncher isGranted: $isGranted")
-                if (isGranted) {
-                    FilePickerDialog.show()
-                } else {
-                    finish()
-                }
-            }
-
-        FilePickerDialog.readPermLauncherSdkR =
-            registerForActivityResult(PermissionContract()) { isGranted ->
-                Log.d(ACTIVITY_TAG, "readPermLauncherSdkR isGranted: $isGranted")
-                if (isGranted) {
-                    FilePickerDialog.show()
-                } else {
-                    finish()
-                }
-            }
+        FilePickerDialog.permissionManager = permissionManager
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -76,21 +58,27 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
             showFragment(savedInstanceState)
         }
 
-        val storageFolderExisting = memoPreferences.getNotesStorage().exists()
-        if (memoPreferences.storageNotAvailable()) {
-            if (!storageFolderExisting) {
-                showNoNoteStorageDialog(RootNotFound(rootPath = memoPreferences.getPath()))
+        permissionManager.askForWriteStorage { granted ->
+            if (!granted) {
+                finish()
             } else {
-                FilePickerDialog.show(this, supportFragmentManager)
-            }
-        } else {
-            if (memoPreferences.isLastLaunchSuccess()) {
-                showFragment(savedInstanceState)
-            } else {
-                showRetrySelectRootDialog(
-                    rootPath = memoPreferences.getPath(),
-                    savedInstanceState = savedInstanceState,
-                )
+                val storageFolderExisting = memoPreferences.getNotesStorage().exists()
+                if (memoPreferences.storageNotAvailable()) {
+                    if (!storageFolderExisting) {
+                        showNoNoteStorageDialog(RootNotFound(rootPath = memoPreferences.getPath()))
+                    } else {
+                        FilePickerDialog.show(this, supportFragmentManager)
+                    }
+                } else {
+                    if (memoPreferences.isLastLaunchSuccess()) {
+                        showFragment(savedInstanceState)
+                    } else {
+                        showRetrySelectRootDialog(
+                            rootPath = memoPreferences.getPath(),
+                            savedInstanceState = savedInstanceState,
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/ArkMediaPlayerFragment.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/ArkMediaPlayerFragment.kt
@@ -60,6 +60,9 @@ class ArkMediaPlayerFragment : BaseEditNoteFragment() {
         return false
     }
 
+    override fun onViewRestoredWithNote(note: Note) {
+    }
+
     private fun initUI() {
         binding.toolbar.ivRightActionIcon.setOnClickListener {
             showDeleteNoteDialog(note)

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/ArkRecorderFragment.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/ArkRecorderFragment.kt
@@ -401,6 +401,11 @@ class ArkRecorderFragment : BaseEditNoteFragment() {
         )
     }
 
+    override fun onViewRestoredWithNote(note: Note) {
+        setNote(note as VoiceNote)
+        initExistingNoteUI()
+    }
+
     private fun saveNote() {
         notesViewModel.onSaveClick(createNewNote(), parentNote = note) { show ->
             activity.showProgressBar(show)

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/EditGraphicNotesFragment.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/EditGraphicNotesFragment.kt
@@ -172,6 +172,12 @@ class EditGraphicNotesFragment : BaseEditNoteFragment() {
         return graphicNotesViewModel.svg().getPaths().isEmpty()
     }
 
+    override fun onViewRestoredWithNote(note: Note) {
+        this.note = note as GraphicNote
+        graphicNotesViewModel.onNoteOpened(note)
+        binding.notesCanvas.invalidate()
+    }
+
     private fun initBottomControls() {
         val tvBrushSize = binding.layoutGraphicsControl.tvBrushSize
         tvBrushSize.setOnClickListener {

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/EditTextNotesFragment.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/EditTextNotesFragment.kt
@@ -75,7 +75,6 @@ class EditTextNotesFragment : BaseEditNoteFragment() {
                 note = it
             }
             noteStr = requireArguments().getString(NOTE_STRING_KEY)
-            notesViewModel.init {}
         }
     }
 
@@ -165,6 +164,9 @@ class EditTextNotesFragment : BaseEditNoteFragment() {
 
     override fun isContentEmpty(): Boolean {
         return binding.editNote.text.toString().trim().isEmpty()
+    }
+
+    override fun onViewRestoredWithNote(note: Note) {
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/NotesFragment.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/fragments/NotesFragment.kt
@@ -271,12 +271,21 @@ class NotesFragment : BaseFragment() {
         initEmptyStateViews()
 
         binding.pbLoading.visible()
-        notesViewModel.apply {
-            setLastLaunchSuccess(false)
-            init {
-                readAllNotes {
-                    onNotesLoaded(it)
-                    setLastLaunchSuccess(true)
+        activity.permissionManager.askForWriteStorage { granted ->
+            if (!granted) {
+                if (isVisible) {
+                    activity.finish()
+                }
+                return@askForWriteStorage
+            } else {
+                notesViewModel.apply {
+                    setLastLaunchSuccess(false)
+                    init {
+                        readAllNotes {
+                            onNotesLoaded(it)
+                            setLastLaunchSuccess(true)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/viewmodels/GraphicNotesViewModel.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/viewmodels/GraphicNotesViewModel.kt
@@ -47,8 +47,10 @@ class GraphicNotesViewModel
             Log.d(TAG, "onNoteOpened")
             viewModelScope.launch {
                 if (editPaths.isNotEmpty()) editPaths.clear()
-                editPaths.addAll(note.svg?.getPaths()!!)
-                svg = note.svg.copy()
+                note.svg?.getPaths()?.let { paths ->
+                    editPaths.addAll(paths)
+                    svg = note.svg.copy()
+                }
             }
         }
 

--- a/app/src/main/java/dev/arkbuilders/arkmemo/ui/viewmodels/NotesViewModel.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/ui/viewmodels/NotesViewModel.kt
@@ -10,6 +10,7 @@ import dev.arkbuilders.arklib.ResourceId
 import dev.arkbuilders.arkmemo.di.IO_DISPATCHER
 import dev.arkbuilders.arkmemo.models.GraphicNote
 import dev.arkbuilders.arkmemo.models.Note
+import dev.arkbuilders.arkmemo.models.NoteType
 import dev.arkbuilders.arkmemo.models.SaveNoteResult
 import dev.arkbuilders.arkmemo.models.TextNote
 import dev.arkbuilders.arkmemo.models.VoiceNote
@@ -72,6 +73,25 @@ class NotesViewModel
                         notes.value = it.sortedByDescending { note -> note.resource?.modified }
                         onSuccess(notes.value)
                     }
+                }
+            }
+        }
+
+        fun findNote(
+            id: ResourceId,
+            type: NoteType,
+            onResult: (note: Note?) -> Unit,
+        ) {
+            viewModelScope.launch(iODispatcher) {
+                val noteRepo =
+                    when (type) {
+                        NoteType.TEXT -> textNotesRepo
+                        NoteType.VOICE -> voiceNotesRepo
+                        NoteType.GRAPHIC -> graphicNotesRepo
+                    }
+                val note = noteRepo.findNote(id)
+                withContext(Dispatchers.Main) {
+                    onResult.invoke(note)
                 }
             }
         }

--- a/app/src/main/java/dev/arkbuilders/arkmemo/utils/Permission.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/utils/Permission.kt
@@ -1,7 +1,11 @@
 package dev.arkbuilders.arkmemo.utils
 
+import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Environment
+import androidx.core.content.ContextCompat
 
 object Permission {
     fun hasPermission(
@@ -9,5 +13,16 @@ object Permission {
         permission: String,
     ): Boolean {
         return context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+    }
+
+    fun hasStoragePermission(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Environment.isExternalStorageManager()
+        } else {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            ) == PackageManager.PERMISSION_GRANTED
+        }
     }
 }

--- a/app/src/main/java/dev/arkbuilders/arkmemo/utils/PermissionManager.kt
+++ b/app/src/main/java/dev/arkbuilders/arkmemo/utils/PermissionManager.kt
@@ -1,0 +1,38 @@
+package dev.arkbuilders.arkmemo.utils
+
+import android.Manifest
+import android.os.Build
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import dev.arkbuilders.arkmemo.BuildConfig
+import dev.arkbuilders.arkmemo.contracts.PermissionContract
+
+class PermissionManager(val activity: ComponentActivity) {
+    private var permissionResultCallback: ((granted: Boolean) -> Unit)? = null
+    private val permissionLauncher: ActivityResultLauncher<String> =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.registerForActivityResult(PermissionContract()) { isGranted ->
+                permissionResultCallback?.invoke(isGranted)
+            }
+        } else {
+            activity.registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+                permissionResultCallback?.invoke(isGranted)
+            }
+        }
+
+    fun askForWriteStorage(onResult: ((granted: Boolean) -> Unit)? = null) {
+        if (Permission.hasStoragePermission(activity)) {
+            onResult?.invoke(true)
+            return
+        }
+
+        permissionResultCallback = onResult
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val packageUri = "package:" + BuildConfig.APPLICATION_ID
+            permissionLauncher.launch(packageUri)
+        } else {
+            permissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        }
+    }
+}


### PR DESCRIPTION
* Fix crash in Android 10 after disable Storage permission and open app
* Update permission request flow to make sure storage permission is asked before accessing data

**Ticket:** https://app.asana.com/0/1207829522063916/1208903376779601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced unified handling for storage permissions, simplifying permission requests and checks across the app.
  * Added support for restoring note state after configuration changes or process restarts, allowing notes to be recovered seamlessly.
  * Added ability to find and retrieve individual notes by their unique ID and type.

* **Improvements**
  * Centralized and streamlined permission logic for file access, reducing complexity in dialogs and activities.
  * Enhanced safety when handling note data, minimizing the risk of errors due to missing or invalid content.

* **Bug Fixes**
  * Prevented potential crashes by safely handling nullable note data in graphic notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->